### PR TITLE
Avoid check preview status if sizes are not standard

### DIFF
--- a/libusbcamera/src/main/java/com/serenegiant/usb/common/AbstractUVCCameraHandler.java
+++ b/libusbcamera/src/main/java/com/serenegiant/usb/common/AbstractUVCCameraHandler.java
@@ -918,7 +918,7 @@ public abstract class AbstractUVCCameraHandler extends Handler {
 
         // 获取支持的分辨率
         public List<Size> getSupportedSizes() {
-            if ((mUVCCamera == null) || !mIsPreviewing)
+            if ((mUVCCamera == null))
                 return null;
             return mUVCCamera.getSupportedSizeList();
         }


### PR DESCRIPTION
Avoid this check allow some cameras to configure non standard preview sizes.

This is just a quick fix, probably we should check if predefined preview size is supported, and if not trigger directly the preview size dialog

I can rework that if looks interesting